### PR TITLE
Allow loading of the `.cdn_auth` file from the working dir, home dir or from an environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "email": "me@juliocarlosmenendez.com",
     "url": "http://juliocarlosmenendez.com"
   },
+  "contributors": [
+    {
+      "name": "Armando Perez Marques",
+      "email": "gmandx@gmail.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/juliomenendez/grunt-cdn-refresh.git"
@@ -26,9 +32,11 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "grunt-contrib-jshint": "0.1.1rc6",
-    "grunt": "~0.4.0",
     "akamai": "~0.1.0"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "0.1.1rc6",
+    "grunt": "~0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/cdn_refresh.js
+++ b/tasks/cdn_refresh.js
@@ -10,40 +10,62 @@
 
 module.exports = function(grunt) {
 
-  var fs = require('fs'),
-      akamai = require('akamai');
+    var fs = require('fs'),
+        akamai = require('akamai'),
+        path = require('path'),
 
-  var refreshers = {
-    akamai: function(data, doneFn) {
-      var purge = new akamai.purge(data.urls, {
-        user: data.user,
-        password: data.password,
-        domain: data.domain || 'production',
-        notify: data.notify
-      }, function(error, response) {
-        if (error) {
-          grunt.log.error(error);
-          doneFn(false);
+        resolveHome = function (string) {
+            if (string.substr(0,1) === '~') {
+                var envVar = (process.platform.substr(0, 3) === 'win') ? 'USERPROFILE' : 'HOME';
+                string = path.join(process.env[envVar], string.substr(1));
+            }
+            return path.resolve(string);
+        },
+
+        loadJSON = function (path) {
+            return JSON.parse(fs.readFileSync(path));
+        },
+
+        refreshers = {
+            akamai: function(data, doneFn) {
+                var purge = new akamai.purge(data.urls, {
+                    user: data.user,
+                    password: data.password,
+                    domain: data.domain || 'production',
+                    notify: data.notify
+                }, function(error, response) {
+                    if (error) {
+                        grunt.log.error(error);
+                        doneFn(false);
+                    }
+
+                    doneFn('refresh request sent.');
+                });
+            }
+        };
+
+    grunt.registerMultiTask('cdn_refresh', 'Refresh content in a CDN.', function() {
+        var data = this.data,
+            authFromFile = {},
+            authFile,
+            done = this.async(),
+            provider = data.provider || this.target;
+
+        authFile = path.join(process.cwd(), data.authFile || '.cdn_auth');
+
+        if (fs.existsSync(authFile)) {
+            authFromFile = loadJSON(authFile)[provider] || {};
+        } else {
+            authFile = resolveHome(process.env.AKAMAI_REST_AUTH || '~/.cdn_auth');
+            if (fs.existsSync(authFile)) {
+                authFromFile = loadJSON(authFile)[provider] || {};
+            }
         }
 
-        doneFn('refresh request sent.');
-      });
-    }
-  };
+        data.user = data.user || authFromFile.user;
+        data.password = data.password || authFromFile.password;
+        data.notify = data.notify || authFromFile.email;
 
-  grunt.registerMultiTask('cdn_refresh', 'Refresh content in a CDN.', function() {
-    var data = this.data,
-        done = this.async(),
-        authFile = data['authFile'] || '.cdn_auth';
-
-    if (fs.existsSync(authFile)) {
-        var authData = JSON.parse(grunt.file.read(authFile))[this.target];
-        data.user = data.user || authData.user;
-        data.password = data.password || authData.password;
-        data.notify = data.notify || authData.email;
-    }
-
-    refreshers[this.target](data, done);
-  });
-
+        refreshers[provider](data, done);
+    });
 };


### PR DESCRIPTION
Also moved the `grunt` and `grunt-contrib-jshint` modules from `dependencies` to `devDependencies` in `package.json`, since those modules are not needed at runtime.